### PR TITLE
sample anime_watchlist has been fixed

### DIFF
--- a/resources/anime_watchlist
+++ b/resources/anime_watchlist
@@ -10,7 +10,7 @@
         "storeSince": "01-00"
     }, 
     {
-        "lastDownloaded": "hippuuden-395", 
+        "lastDownloaded": "01-395", 
         "name": "Naruto Shippuuden", 
         "storeSince": "01-00"
     }, 
@@ -20,7 +20,7 @@
         "storeSince": "01-00"
     }, 
     {
-        "lastDownloaded": "2-15", 
+        "lastDownloaded": "02-15", 
         "name": "log horizon", 
         "storeSince": "01-00"
     }, 
@@ -30,7 +30,7 @@
         "storeSince": "01-00"
     }, 
     {
-        "lastDownloaded": "2-41", 
+        "lastDownloaded": "02-41", 
         "name": "fairy tail", 
         "storeSince": "01-00"
     }


### PR DESCRIPTION
I saw sample anime_watchlist has broken by an old bug (looking for "s" to find season was problematic for Naruto Shippuuden Episodes). I thought PR is needed.
